### PR TITLE
use singular for some post operation ids

### DIFF
--- a/dist/api_types.ts
+++ b/dist/api_types.ts
@@ -4187,7 +4187,7 @@ export type GetCommentsResponse = {
 /**
  * Response from the POST /v1/files/{file_key}/comments endpoint.
  */
-export type PostCommentsResponse = Comment
+export type PostCommentResponse = Comment
 
 /**
  * Response from the DELETE /v1/files/{file_key}/comments/{comment_id} endpoint.
@@ -4219,7 +4219,7 @@ export type GetCommentReactionsResponse = {
 /**
  * Response from the POST /v1/files/{file_key}/comments/{comment_id}/reactions endpoint.
  */
-export type PostCommentReactionsResponse = {
+export type PostCommentReactionResponse = {
   /**
    * The status of the request.
    */
@@ -4424,7 +4424,7 @@ export type GetStyleResponse = {
 /**
  * Response from the POST /v2/webhooks endpoint.
  */
-export type PostWebhooksResponse = WebhookV2
+export type PostWebhookResponse = WebhookV2
 
 /**
  * Response from the GET /v2/webhooks/{webhook_id} endpoint.
@@ -5044,7 +5044,7 @@ export type GetCommentsQueryParams = {
 /**
  * Path parameters for POST /v1/files/{file_key}/comments
  */
-export type PostCommentsPathParams = {
+export type PostCommentPathParams = {
   /**
    * File to add comments in. This can be a file key or branch key. Use `GET /v1/files/:key` with the
    * `branch_data` query param to get the branch key.
@@ -5055,7 +5055,7 @@ export type PostCommentsPathParams = {
 /**
  * Request body parameters for POST /v1/files/{file_key}/comments
  */
-export type PostCommentsRequestBody = {
+export type PostCommentRequestBody = {
   /**
    * The text contents of the comment to post.
    */
@@ -5136,7 +5136,7 @@ export type GetCommentReactionsQueryParams = {
 /**
  * Path parameters for POST /v1/files/{file_key}/comments/{comment_id}/reactions
  */
-export type PostCommentReactionsPathParams = {
+export type PostCommentReactionPathParams = {
   /**
    * File to post comment reactions to. This can be a file key or branch key. Use `GET
    * /v1/files/:key` with the `branch_data` query param to get the branch key.
@@ -5151,7 +5151,7 @@ export type PostCommentReactionsPathParams = {
 /**
  * Request body parameters for POST /v1/files/{file_key}/comments/{comment_id}/reactions
  */
-export type PostCommentReactionsRequestBody = { emoji: Emoji }
+export type PostCommentReactionRequestBody = { emoji: Emoji }
 
 /**
  * Path parameters for GET /v1/teams/{team_id}/components
@@ -5309,7 +5309,7 @@ export type GetStylePathParams = {
 /**
  * Request body parameters for POST /v2/webhooks
  */
-export type PostWebhooksRequestBody = {
+export type PostWebhookRequestBody = {
   event_type: WebhookV2Event
 
   /**

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -616,7 +616,7 @@ paths:
         - OAuth2:
             - file_comments:write
       description: Posts a new comment on the file.
-      operationId: postComments
+      operationId: postComment
       parameters:
         - name: file_key
           in: path
@@ -653,7 +653,7 @@ paths:
                 - message
       responses:
         "200":
-          $ref: "#/components/responses/PostCommentsResponse"
+          $ref: "#/components/responses/PostCommentResponse"
         "400":
           $ref: "#/components/responses/BadRequestErrorResponseWithErrorBoolean"
         "403":
@@ -754,7 +754,7 @@ paths:
         - OAuth2:
             - file_comments:write
       description: Posts a new comment reaction on a file comment.
-      operationId: postCommentReactions
+      operationId: postCommentReaction
       parameters:
         - name: file_key
           in: path
@@ -784,7 +784,7 @@ paths:
                 - emoji
       responses:
         "200":
-          $ref: "#/components/responses/PostCommentReactionsResponse"
+          $ref: "#/components/responses/PostCommentReactionResponse"
         "400":
           $ref: "#/components/responses/BadRequestErrorResponseWithErrorBoolean"
         "403":
@@ -1213,7 +1213,7 @@ paths:
         PING event to the endpoint when it is created. If this behavior is not
         desired, you can create the webhook and set the status to PAUSED and
         reactivate it later.
-      operationId: postWebhooks
+      operationId: postWebhook
       requestBody:
         description: The webhook to create.
         required: true
@@ -1435,7 +1435,7 @@ paths:
                     strategy.
       responses:
         "200":
-          $ref: "#/components/responses/PostWebhooksResponse"
+          $ref: "#/components/responses/PostWebhookResponse"
         "400":
           $ref: "#/components/responses/BadRequestErrorResponseWithErrorBoolean"
         "403":
@@ -6934,7 +6934,7 @@ components:
                   $ref: "#/components/schemas/Comment"
             required:
               - comments
-    PostCommentsResponse:
+    PostCommentResponse:
       description: Response from the POST /v1/files/{file_key}/comments endpoint.
       content:
         application/json:
@@ -6979,7 +6979,7 @@ components:
             required:
               - reactions
               - pagination
-    PostCommentReactionsResponse:
+    PostCommentReactionResponse:
       description: Response from the POST
         /v1/files/{file_key}/comments/{comment_id}/reactions endpoint.
       content:
@@ -7291,7 +7291,7 @@ components:
               - status
               - error
               - meta
-    PostWebhooksResponse:
+    PostWebhookResponse:
       description: Response from the POST /v2/webhooks endpoint.
       content:
         application/json:


### PR DESCRIPTION
This change updates the REST API schema so that the `POST` operation for comments, comment reactions, and webhooks all use the singular form. E.g., `postWebhook` instead of `postWebhooks`. This is a little more natural and aligns with other operations that use singular when the subject is a single object, e.g. `getWebhook`.