### PR TITLE
Update README example to use type imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install --save-dev @figma/rest-api-spec
 Then import the types that you need:
 
 ```ts
-import { GetFileResponse } from '@figma/rest-api-spec'
+import { type GetFileResponse } from '@figma/rest-api-spec'
 
 // Many popular HTTP clients let you annotate response types
 const result = await axios.get<GetFileResponse>(url);


### PR DESCRIPTION
Hi folks,

Tiny PR to just get the right type of import on the code sample you show.

It confused me when I saw a dev dependency and then a JS import, so hopefully that confusion can be avoided for others. Besides, importing types as types yields more consistent outcomes with non-type-aware transpilers.

Thanks