### PR TITLE
update to 0.20.0: deletedButReferenced, backfill of annotations/measurements

### DIFF
--- a/dist/api_types.ts
+++ b/dist/api_types.ts
@@ -680,6 +680,8 @@ export type DevStatusTrait = {
   }
 }
 
+export type AnnotationsTrait = object
+
 export type FrameTraits = IsLayerTrait &
   HasBlendModeAndOpacityTrait &
   HasChildrenTrait &
@@ -692,7 +694,8 @@ export type FrameTraits = IsLayerTrait &
   HasMaskTrait &
   TransitionSourceTrait &
   IndividualStrokesTrait &
-  DevStatusTrait
+  DevStatusTrait &
+  AnnotationsTrait
 
 export type DefaultShapeTraits = IsLayerTrait &
   HasBlendModeAndOpacityTrait &
@@ -705,7 +708,10 @@ export type DefaultShapeTraits = IsLayerTrait &
 
 export type CornerRadiusShapeTraits = DefaultShapeTraits & CornerTrait
 
-export type RectangularShapeTraits = DefaultShapeTraits & CornerTrait & IndividualStrokesTrait
+export type RectangularShapeTraits = DefaultShapeTraits &
+  CornerTrait &
+  IndividualStrokesTrait &
+  AnnotationsTrait
 
 export type Node =
   | BooleanOperationNode
@@ -768,6 +774,8 @@ export type CanvasNode = {
    * The device used to view a prototype.
    */
   prototypeDevice: PrototypeDevice
+
+  measurements?: Measurement[]
 } & IsLayerTrait &
   HasExportSettingsTrait
 
@@ -868,21 +876,24 @@ export type VectorNode = {
    * The type of this node, represented by the string literal "VECTOR"
    */
   type: 'VECTOR'
-} & CornerRadiusShapeTraits
+} & CornerRadiusShapeTraits &
+  AnnotationsTrait
 
 export type StarNode = {
   /**
    * The type of this node, represented by the string literal "STAR"
    */
   type: 'STAR'
-} & CornerRadiusShapeTraits
+} & CornerRadiusShapeTraits &
+  AnnotationsTrait
 
 export type LineNode = {
   /**
    * The type of this node, represented by the string literal "LINE"
    */
   type: 'LINE'
-} & DefaultShapeTraits
+} & DefaultShapeTraits &
+  AnnotationsTrait
 
 export type EllipseNode = {
   /**
@@ -891,14 +902,16 @@ export type EllipseNode = {
   type: 'ELLIPSE'
 
   arcData: ArcData
-} & DefaultShapeTraits
+} & DefaultShapeTraits &
+  AnnotationsTrait
 
 export type RegularPolygonNode = {
   /**
    * The type of this node, represented by the string literal "REGULAR_POLYGON"
    */
   type: 'REGULAR_POLYGON'
-} & CornerRadiusShapeTraits
+} & CornerRadiusShapeTraits &
+  AnnotationsTrait
 
 export type RectangleNode = {
   /**
@@ -913,7 +926,8 @@ export type TextNode = {
    */
   type: 'TEXT'
 } & DefaultShapeTraits &
-  TypePropertiesTrait
+  TypePropertiesTrait &
+  AnnotationsTrait
 
 export type TableNode = {
   /**
@@ -2653,6 +2667,51 @@ export type ConditionalBlock = {
 }
 
 /**
+ * A pinned distance between two nodes in Dev Mode
+ */
+export type Measurement = {
+  id: string
+
+  start: MeasurementStartEnd
+
+  end: MeasurementStartEnd
+
+  offset: MeasurementOffsetInner | MeasurementOffsetOuter
+
+  /**
+   * When manually overridden, the displayed value of the measurement
+   */
+  freeText?: string
+}
+
+/**
+ * The node and side a measurement is pinned to
+ */
+export type MeasurementStartEnd = {
+  nodeId: string
+
+  side: 'TOP' | 'RIGHT' | 'BOTTOM' | 'LEFT'
+}
+
+/**
+ * Measurement offset relative to the inside of the start node
+ */
+export type MeasurementOffsetInner = {
+  type: 'INNER'
+
+  relative: number
+}
+
+/**
+ * Measurement offset relative to the outside of the start node
+ */
+export type MeasurementOffsetOuter = {
+  type: 'OUTER'
+
+  fixed: number
+}
+
+/**
  * Position of a comment relative to the frame to which it is attached.
  */
 export type FrameOffset = {
@@ -3973,6 +4032,13 @@ export type LocalVariable = {
   scopes: VariableScope[]
 
   codeSyntax: VariableCodeSyntax
+
+  /**
+   * Indicates that the variable was deleted in the editor, but the document may still contain
+   * references to the variable. References to the variable may exist through bound values or variable
+   * aliases.
+   */
+  deletedButReferenced?: boolean
 }
 
 /**

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Figma API
-  version: 0.19.0
+  version: 0.20.0
   description: |-
     This is the OpenAPI specification for the [Figma REST API](https://www.figma.com/developers/api).
 
@@ -3029,6 +3029,9 @@ components:
                 the design and what has changed.
           required:
             - type
+    AnnotationsTrait:
+      type: object
+      properties: {}
     FrameTraits:
       allOf:
         - $ref: "#/components/schemas/IsLayerTrait"
@@ -3044,6 +3047,7 @@ components:
         - $ref: "#/components/schemas/TransitionSourceTrait"
         - $ref: "#/components/schemas/IndividualStrokesTrait"
         - $ref: "#/components/schemas/DevStatusTrait"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     DefaultShapeTraits:
       allOf:
         - $ref: "#/components/schemas/IsLayerTrait"
@@ -3063,6 +3067,7 @@ components:
         - $ref: "#/components/schemas/DefaultShapeTraits"
         - $ref: "#/components/schemas/CornerTrait"
         - $ref: "#/components/schemas/IndividualStrokesTrait"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     Node:
       oneOf:
         - $ref: "#/components/schemas/BooleanOperationNode"
@@ -3168,6 +3173,10 @@ components:
             prototypeDevice:
               $ref: "#/components/schemas/PrototypeDevice"
               description: The device used to view a prototype.
+            measurements:
+              type: array
+              items:
+                $ref: "#/components/schemas/Measurement"
           required:
             - type
             - children
@@ -3345,6 +3354,7 @@ components:
           required:
             - type
         - $ref: "#/components/schemas/CornerRadiusShapeTraits"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     StarNode:
       allOf:
         - type: object
@@ -3357,6 +3367,7 @@ components:
           required:
             - type
         - $ref: "#/components/schemas/CornerRadiusShapeTraits"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     LineNode:
       allOf:
         - type: object
@@ -3369,6 +3380,7 @@ components:
           required:
             - type
         - $ref: "#/components/schemas/DefaultShapeTraits"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     EllipseNode:
       allOf:
         - type: object
@@ -3384,6 +3396,7 @@ components:
             - type
             - arcData
         - $ref: "#/components/schemas/DefaultShapeTraits"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     RegularPolygonNode:
       allOf:
         - type: object
@@ -3397,6 +3410,7 @@ components:
           required:
             - type
         - $ref: "#/components/schemas/CornerRadiusShapeTraits"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     RectangleNode:
       allOf:
         - type: object
@@ -3423,6 +3437,7 @@ components:
             - type
         - $ref: "#/components/schemas/DefaultShapeTraits"
         - $ref: "#/components/schemas/TypePropertiesTrait"
+        - $ref: "#/components/schemas/AnnotationsTrait"
     TableNode:
       allOf:
         - type: object
@@ -5473,6 +5488,70 @@ components:
             $ref: "#/components/schemas/Action"
       required:
         - actions
+    Measurement:
+      type: object
+      description: A pinned distance between two nodes in Dev Mode
+      properties:
+        id:
+          type: string
+        start:
+          $ref: "#/components/schemas/MeasurementStartEnd"
+        end:
+          $ref: "#/components/schemas/MeasurementStartEnd"
+        offset:
+          oneOf:
+            - $ref: "#/components/schemas/MeasurementOffsetInner"
+            - $ref: "#/components/schemas/MeasurementOffsetOuter"
+        freeText:
+          type: string
+          description: When manually overridden, the displayed value of the measurement
+      required:
+        - id
+        - start
+        - end
+        - offset
+    MeasurementStartEnd:
+      type: object
+      description: The node and side a measurement is pinned to
+      properties:
+        nodeId:
+          type: string
+        side:
+          type: string
+          enum:
+            - TOP
+            - RIGHT
+            - BOTTOM
+            - LEFT
+      required:
+        - nodeId
+        - side
+    MeasurementOffsetInner:
+      type: object
+      description: Measurement offset relative to the inside of the start node
+      properties:
+        type:
+          type: string
+          enum:
+            - INNER
+        relative:
+          type: number
+      required:
+        - type
+        - relative
+    MeasurementOffsetOuter:
+      type: object
+      description: Measurement offset relative to the outside of the start node
+      properties:
+        type:
+          type: string
+          enum:
+            - OUTER
+        fixed:
+          type: number
+      required:
+        - type
+        - fixed
     FrameOffset:
       type: object
       description: Position of a comment relative to the frame to which it is attached.
@@ -6825,6 +6904,12 @@ components:
             $ref: "#/components/schemas/VariableScope"
         codeSyntax:
           $ref: "#/components/schemas/VariableCodeSyntax"
+        deletedButReferenced:
+          type: boolean
+          description: Indicates that the variable was deleted in the editor, but the
+            document may still contain references to the variable. References to
+            the variable may exist through bound values or variable aliases.
+          default: false
       required:
         - id
         - name


### PR DESCRIPTION
This change publicizes the new `deletedButReferenced` property for local variables.

It also contains a backfill of annotations and measurements objects, which have been in the public API for a while but were never added to this spec.