### PR TITLE
Add containingComponentSet to FrameInfo

### DIFF
--- a/dist/api_types.ts
+++ b/dist/api_types.ts
@@ -2923,6 +2923,18 @@ export type FrameInfo = {
    * The name of the page containing the frame node.
    */
   pageName: string
+
+  /**
+   * Deprecated - Use containingComponentSet instead.
+   *
+   * @deprecated
+   */
+  containingStateGroup?: object | null
+
+  /**
+   * The component set node that contains the frame node.
+   */
+  containingComponentSet?: object | null
 }
 
 /**

--- a/dist/api_types.ts
+++ b/dist/api_types.ts
@@ -2929,12 +2929,32 @@ export type FrameInfo = {
    *
    * @deprecated
    */
-  containingStateGroup?: object | null
+  containingStateGroup?: {
+    /**
+     * The ID of the state group node.
+     */
+    nodeId?: string
+
+    /**
+     * The name of the state group node.
+     */
+    name?: string
+  } | null
 
   /**
    * The component set node that contains the frame node.
    */
-  containingComponentSet?: object | null
+  containingComponentSet?: {
+    /**
+     * The ID of the component set node.
+     */
+    nodeId?: string
+
+    /**
+     * The name of the component set node.
+     */
+    name?: string
+  } | null
 }
 
 /**

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5947,29 +5947,29 @@ components:
           description: The name of the page containing the frame node.
         containingStateGroup:
           deprecated: true
-          type:
-            - object
-            - "null"
           description: Deprecated - Use containingComponentSet instead.
-          properties:
-            nodeId:
-              type: string
-              description: The ID of the state group node.
-            name:
-              type: string
-              description: The name of the state group node.
+          oneOf:
+            - type: object
+              properties:
+                nodeId:
+                  type: string
+                  description: The ID of the state group node.
+                name:
+                  type: string
+                  description: The name of the state group node.
+            - type: "null"
         containingComponentSet:
-          type:
-            - object
-            - "null"
           description: The component set node that contains the frame node.
-          properties:
-            nodeId:
-              type: string
-              description: The ID of the component set node.
-            name:
-              type: string
-              description: The name of the component set node.
+          oneOf:
+            - type: object
+              properties:
+                nodeId:
+                  type: string
+                  description: The ID of the component set node.
+                name:
+                  type: string
+                  description: The name of the component set node.
+            - type: "null"
       required:
         - pageId
         - pageName

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Figma API
-  version: 0.25.0
+  version: 0.26.0
   description: |-
     This is the OpenAPI specification for the [Figma REST API](https://www.figma.com/developers/api).
 
@@ -5945,6 +5945,31 @@ components:
         pageName:
           type: string
           description: The name of the page containing the frame node.
+        containingStateGroup:
+          deprecated: true
+          type:
+            - object
+            - "null"
+          description: Deprecated - Use containingComponentSet instead.
+          properties:
+            nodeId:
+              type: string
+              description: The ID of the state group node.
+            name:
+              type: string
+              description: The name of the state group node.
+        containingComponentSet:
+          type:
+            - object
+            - "null"
+          description: The component set node that contains the frame node.
+          properties:
+            nodeId:
+              type: string
+              description: The ID of the component set node.
+            name:
+              type: string
+              description: The name of the component set node.
       required:
         - pageId
         - pageName


### PR DESCRIPTION
Add `containingComponentSet` and `containingStateGroup` (deprecated) to the FrameInfo type. This addresses #29.