### PR TITLE
Update page limit of team/components endpoint

### DIFF
--- a/dist/api_types.ts
+++ b/dist/api_types.ts
@@ -6673,7 +6673,7 @@ export type GetTeamComponentsPathParams = {
  */
 export type GetTeamComponentsQueryParams = {
   /**
-   * Number of items to return in a paged list of results. Defaults to 30.
+   * Number of items to return in a paged list of results. Defaults to 30. Maximum of 1000.
    */
   page_size?: number
   /**

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -889,7 +889,8 @@ paths:
             type: string
         - name: page_size
           in: query
-          description: Number of items to return in a paged list of results. Defaults to 30.
+          description: Number of items to return in a paged list of results. Defaults to
+            30. Maximum of 1000.
           schema:
             type: number
             default: 30


### PR DESCRIPTION
This PR contains the generated changes from https://github.com/figma/figma/pull/514844
TL;DR - we added a max page size of 1000 to the :team/components endpoint