### PR TITLE
add EditorType definition

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -7209,11 +7209,8 @@ components:
           type: string
           description: Name of the file.
         editor_type:
-          type: string
+          $ref: "#/components/schemas/EditorType"
           description: Indicates if the object is a file on Figma Design or FigJam.
-          enum:
-            - figma
-            - figjam
         link_access:
           $ref: "#/components/schemas/LinkAccess"
           description: Access policy for users who have the link to the file.
@@ -7348,12 +7345,9 @@ components:
           type: string
           description: Name of the plugin.
         editor_type:
-          type: string
+          $ref: "#/components/schemas/EditorType"
           description: Indicates if the object is a plugin is available on Figma Design or
             FigJam.
-          enum:
-            - figma
-            - figjam
       required:
         - type
         - id
@@ -7375,12 +7369,9 @@ components:
           type: string
           description: Name of the widget.
         editor_type:
-          type: string
+          $ref: "#/components/schemas/EditorType"
           description: Indicates if the object is a widget available on Figma Design or
             FigJam.
-          enum:
-            - figma
-            - figjam
       required:
         - type
         - id
@@ -8509,6 +8500,16 @@ components:
         - error
         - status
         - message
+    EditorType:
+      type: string
+      description: The type of editor.
+      enum:
+        - figma
+        - figjam
+        - slides
+        - buzz
+        - sites
+        - make
     LinkAccess:
       type: string
       description: Access policy for users who have the link to the resource.
@@ -8545,10 +8546,7 @@ components:
                 format: date-time
                 description: The UTC ISO 8601 time at which the file was last modified.
               editorType:
-                type: string
-                enum:
-                  - figma
-                  - figjam
+                $ref: "#/components/schemas/EditorType"
                 description: The type of editor associated with this file.
               thumbnailUrl:
                 type: string
@@ -8640,10 +8638,7 @@ components:
                 format: date-time
                 description: The UTC ISO 8601 time at which the file was last modified.
               editorType:
-                type: string
-                enum:
-                  - figma
-                  - figjam
+                $ref: "#/components/schemas/EditorType"
                 description: The type of editor associated with this file.
               thumbnailUrl:
                 type: string
@@ -8776,14 +8771,7 @@ components:
                 type: string
                 description: A URL to a thumbnail image of the file.
               editorType:
-                type: string
-                enum:
-                  - figma
-                  - figjam
-                  - slides
-                  - buzz
-                  - sites
-                  - make
+                $ref: "#/components/schemas/EditorType"
                 description: The type of editor associated with this file.
               role:
                 $ref: "#/components/schemas/Role"


### PR DESCRIPTION
An enumeration for the `editor_type` property is defined multiple times. Move the definition to the schemas and share it.