### PR TITLE
add ConnectorStrokeCap definition

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4133,26 +4133,12 @@ components:
               $ref: "#/components/schemas/ConnectorEndpoint"
               description: The ending point of the connector.
             connectorStartStrokeCap:
-              type: string
+              $ref: "#/components/schemas/ConnectorStrokeCap"
               description: A string enum describing the end cap of the start of the connector.
-              enum:
-                - NONE
-                - LINE_ARROW
-                - TRIANGLE_ARROW
-                - DIAMOND_FILLED
-                - CIRCLE_FILLED
-                - TRIANGLE_FILLED
               default: NONE
             connectorEndStrokeCap:
-              type: string
+              $ref: "#/components/schemas/ConnectorStrokeCap"
               description: A string enum describing the end cap of the end of the connector.
-              enum:
-                - NONE
-                - LINE_ARROW
-                - TRIANGLE_ARROW
-                - DIAMOND_FILLED
-                - CIRCLE_FILLED
-                - TRIANGLE_FILLED
               default: NONE
             connectorLineType:
               $ref: "#/components/schemas/ConnectorLineType"
@@ -5601,6 +5587,16 @@ components:
                 - LEFT
                 - RIGHT
                 - CENTER
+    ConnectorStrokeCap:
+      type: string
+      description: Connector stroke cap.
+      enum:
+        - NONE
+        - LINE_ARROW
+        - TRIANGLE_ARROW
+        - DIAMOND_FILLED
+        - CIRCLE_FILLED
+        - TRIANGLE_FILLED
     ConnectorLineType:
       type: string
       description: Connector line type.


### PR DESCRIPTION
An enumeration is defined in both the `connectorStartStrokeCap` and `connectorEndStrokeCap` property in `ConnectorNode`. Move the definition the schemas and share it.