### PR TITLE
define enum for WebhookV2.context

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -6765,6 +6765,10 @@ components:
           type: string
           description: The type of context this webhook is attached to. The value will be
             "PROJECT", "TEAM", or "FILE"
+          enum:
+            - PROJECT
+            - TEAM
+            - FILE
         context_id:
           type: string
           description: The ID of the context this webhook is attached to


### PR DESCRIPTION
An enumeration is described in the property's description. Add the values to an `enum` definition.