### PR TITLE
add discriminator for NoiseEffect

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5087,6 +5087,12 @@ components:
         - $ref: "#/components/schemas/MonotoneNoiseEffect"
         - $ref: "#/components/schemas/MultitoneNoiseEffect"
         - $ref: "#/components/schemas/DuotoneNoiseEffect"
+      discriminator:
+        propertyName: noiseType
+        mapping:
+          MONOTONE: "#/components/schemas/MonotoneNoiseEffect"
+          MULTITONE: "#/components/schemas/MultitoneNoiseEffect"
+          DUOTONE: "#/components/schemas/DuotoneNoiseEffect"
     Effect:
       oneOf:
         - $ref: "#/components/schemas/DropShadowEffect"


### PR DESCRIPTION
The type of `NoiseEffect` is announced in the `noiseType` property. Provide a mapping to the types based on `noiseType`'s value.