### PR TITLE
add discriminator for Measurement.offset

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -6260,6 +6260,11 @@ components:
           oneOf:
             - $ref: "#/components/schemas/MeasurementOffsetInner"
             - $ref: "#/components/schemas/MeasurementOffsetOuter"
+          discriminator:
+            propertyName: type
+            mapping:
+              INNER: "#/components/schemas/MeasurementOffsetInner"
+              OUTER: "#/components/schemas/MeasurementOffsetOuter"
         freeText:
           type: string
           description: When manually overridden, the displayed value of the measurement


### PR DESCRIPTION
Whether a value is a `MeasurementOffsetInner` or a `MeasurementOffsetOuter` is specified in its `type` property. Add a discriminator for this.