### PR TITLE
add DevModeStatus definition

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3497,11 +3497,7 @@ components:
             status applied to it.
           properties:
             type:
-              type: string
-              enum:
-                - NONE
-                - READY_FOR_DEV
-                - COMPLETED
+              $ref: "#/components/schemas/DevModeStatus"
             description:
               type: string
               description: An optional field where the designer can add more information about
@@ -4216,6 +4212,12 @@ components:
         - $ref: "#/components/schemas/IsLayerTrait"
         - $ref: "#/components/schemas/HasExportSettingsTrait"
         - $ref: "#/components/schemas/HasChildrenTrait"
+    DevModeStatus:
+      type: string
+      enum:
+        - NONE
+        - READY_FOR_DEV
+        - COMPLETED
     RGB:
       type: object
       description: An RGB color
@@ -7172,7 +7174,7 @@ components:
               description: An array of related links that have been applied to the layer in
                 the file
             status:
-              type: string
+              $ref: "#/components/schemas/DevModeStatus"
               description: The Dev Mode status. Either "NONE", "READY_FOR_DEV", or "COMPLETED"
             triggered_by:
               $ref: "#/components/schemas/User"


### PR DESCRIPTION
An enumeration for developer mode status is described in multiple places. Move the definition to the schemas and share it.