### PR TITLE
use LinkAccess definition

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -8640,7 +8640,7 @@ components:
                   $ref: "#/components/schemas/Style"
                 description: A mapping from style IDs to style metadata.
               linkAccess:
-                type: string
+                $ref: "#/components/schemas/LinkAccess"
                 description: The share permission level of the file link.
               mainFileKey:
                 type: string


### PR DESCRIPTION
Use `LinkAccess` within the `GetFileResponse` content.